### PR TITLE
Add tests for new EA builds.

### DIFF
--- a/.github/actions/setup-oracle-graalvm-ea-build/action.yml
+++ b/.github/actions/setup-oracle-graalvm-ea-build/action.yml
@@ -1,0 +1,31 @@
+name: Set up GraalVM JDK EA build
+description: 'Set up GraalVM JDK EA build for testing'
+
+inputs:
+  java-version:
+    description: 'Java version to use'
+    required: false
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up GRAALVM_HOME with EA build
+      shell: bash
+      run: |
+        FILE_NAME="graalvm-jdk.tar.gz"
+        DOWNLOAD_URL=$(jq -r '(.download_base_url + (.files[] | select(.arch == "x64" and .platform == "linux") | .filename))' versions/latest-ea.json)
+        echo "Downloading '${DOWNLOAD_URL}'..."
+        pushd $HOME > /dev/null
+        curl --fail --silent --location --retry 3 --max-time 10 --output "${FILE_NAME}" --request GET "${DOWNLOAD_URL}"
+        tar xzf "${FILE_NAME}"
+        GRAALVM_HOME=$(find $(pwd) -type d -name "graalvm-jdk-*")
+        echo "GRAALVM_HOME=${GRAALVM_HOME}" >> ${GITHUB_ENV}
+        popd > /dev/null
+    - name: Set up JAVA_HOME
+      if: ${{ inputs.java-version }} != ''
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'oracle'
+        java-version: '${{ inputs.java-version }}'
+  

--- a/.github/workflows/micronaut.yml
+++ b/.github/workflows/micronaut.yml
@@ -1,0 +1,85 @@
+#
+# Copyright (c) 2024, 2024, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# The Universal Permissive License (UPL), Version 1.0
+#
+# Subject to the condition set forth below, permission is hereby granted to any
+# person obtaining a copy of this software, associated documentation and/or
+# data (collectively the "Software"), free of charge and under any and all
+# copyright rights in the Software, and any and all patent rights owned or
+# freely licensable by each licensor hereunder covering either (i) the
+# unmodified Software as contributed to or provided by such licensor, or (ii)
+# the Larger Works (as defined below), to deal in both
+#
+# (a) the Software, and
+#
+# (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+# one is included with the Software each a "Larger Work" to which the Software
+# is contributed by such licensors),
+#
+# without restriction, including without limitation the rights to copy, create
+# derivative works of, display, perform, and distribute the Software and make,
+# use, sell, offer for sale, import, export, have made, and have sold the
+# Software and the Larger Work(s), and to sublicense the foregoing rights on
+# either these or other terms.
+#
+# This license is subject to the following condition:
+#
+# The above copyright notice and either this complete permission notice or at a
+# minimum a reference to the UPL must be included in all copies or substantial
+# portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+name: Micronaut Tests
+
+on:
+  pull_request:
+    paths:
+      - '.github/actions/**'
+      - '.github/workflows/micronaut.yml'
+      - 'versions/latest-ea.json'
+  workflow_dispatch:
+
+env:
+  MICRONAUT_CORE_PATH: ${{ github.workspace }}/micronaut-core
+  MICRONAUT_JAVA_VERSION: 21
+  # Enforce experimental option checking in CI (GR-47922)
+  NATIVE_IMAGE_EXPERIMENTAL_OPTIONS_ARE_FATAL: 'true'
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
+jobs:
+  build-graalvm-and-micronaut:
+    name: Native Tests
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout oracle/graal
+      uses: actions/checkout@v4
+    - name: Set up GraalVM JDK EA build
+      uses: ./.github/actions/setup-oracle-graalvm-ea-build
+      with:
+        java-version: ${{ env.MICRONAUT_JAVA_VERSION }}
+    - name: Run nativeTest in Micronaut launch project
+      run: |
+        curl --fail --silent --location --retry 3 --max-time 10 --output demo.zip --request GET 'https://launch.micronaut.io/create/default/com.example.demo?lang=JAVA&build=GRADLE&test=JUNIT&javaVersion=JDK_${{ env.MICRONAUT_JAVA_VERSION }}'
+        unzip demo.zip
+        cd demo
+        ./gradlew nativeTest
+    - name: Checkout micronaut-projects/micronaut-core
+      uses: actions/checkout@v4
+      with:
+        repository: micronaut-projects/micronaut-core
+        path: ${{ env.MICRONAUT_CORE_PATH }}
+    - name: Run nativeTest in micronaut-core
+      run: |
+        cd ${{ env.MICRONAUT_CORE_PATH }}
+        ./gradlew nativeTest

--- a/.github/workflows/reachability-metadata.yml
+++ b/.github/workflows/reachability-metadata.yml
@@ -1,0 +1,120 @@
+#
+# Copyright (c) 2024, 2024, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# The Universal Permissive License (UPL), Version 1.0
+#
+# Subject to the condition set forth below, permission is hereby granted to any
+# person obtaining a copy of this software, associated documentation and/or
+# data (collectively the "Software"), free of charge and under any and all
+# copyright rights in the Software, and any and all patent rights owned or
+# freely licensable by each licensor hereunder covering either (i) the
+# unmodified Software as contributed to or provided by such licensor, or (ii)
+# the Larger Works (as defined below), to deal in both
+#
+# (a) the Software, and
+#
+# (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+# one is included with the Software each a "Larger Work" to which the Software
+# is contributed by such licensors),
+#
+# without restriction, including without limitation the rights to copy, create
+# derivative works of, display, perform, and distribute the Software and make,
+# use, sell, offer for sale, import, export, have made, and have sold the
+# Software and the Larger Work(s), and to sublicense the foregoing rights on
+# either these or other terms.
+#
+# This license is subject to the following condition:
+#
+# The above copyright notice and either this complete permission notice or at a
+# minimum a reference to the UPL must be included in all copies or substantial
+# portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+name: Reachability Metadata Tests
+
+on:
+  pull_request:
+    paths:
+      - '.github/actions/**'
+      - '.github/workflows/reachability-metadata.yml'
+      - 'versions/latest-ea.json'
+  workflow_dispatch:
+
+env:
+  REACHABILITY_METADATA_PATH: ${{ github.workspace }}/graalvm-reachability-metadata
+  MINIMUM_METADATA_JAVA_VERSION: 17
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
+jobs:
+  populate-matrix:
+    name: Populate matrix
+    runs-on: ubuntu-20.04
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+    - name: Checkout oracle/graalvm-reachability-metadata
+      uses: actions/checkout@v4
+      with:
+        repository: oracle/graalvm-reachability-metadata
+        path: ${{ env.REACHABILITY_METADATA_PATH }}
+    - name: "Setup JAVA_HOME"
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'oracle'
+        java-version: ${{ env.MINIMUM_METADATA_JAVA_VERSION }}
+    - name: "Populate matrix"
+      id: set-matrix
+      run: |
+        cd ${{ env.REACHABILITY_METADATA_PATH }}
+        ./gradlew generateMatrixMatchingCoordinates -Pcoordinates=all
+
+  test-all-metadata:
+    name: ${{ matrix.coordinates }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: populate-matrix
+    strategy:
+        fail-fast: false
+        matrix:
+          coordinates: ${{fromJson(needs.populate-matrix.outputs.matrix).coordinates}}
+    steps:
+      - name: Checkout oracle-graalvm-ea-builds for setup-oracle-graalvm-ea-build
+        uses: actions/checkout@v4
+      - name: "Checkout oracle/graalvm-reachability-metadata"
+        uses: actions/checkout@v4
+        with:
+          repository: oracle/graalvm-reachability-metadata
+          path: ${{ env.REACHABILITY_METADATA_PATH }}
+      - name: Set up GraalVM JDK EA build
+        uses: ./.github/actions/setup-oracle-graalvm-ea-build
+        with:
+          java-version: ${{ env.MINIMUM_METADATA_JAVA_VERSION }}
+      - name: "Pull allowed docker images"
+        run: |
+          cd ${{ env.REACHABILITY_METADATA_PATH }}
+          ./gradlew pullAllowedDockerImages --coordinates=${{ matrix.coordinates }}
+      - name: "Disable docker"
+        run: |
+          cd ${{ env.REACHABILITY_METADATA_PATH }}
+          sudo apt-get install openbsd-inetd
+          sudo bash -c "cat ./.github/workflows/discard-port.conf >> /etc/inetd.conf"
+          sudo systemctl start inetd
+          sudo mkdir /etc/systemd/system/docker.service.d
+          sudo bash -c "cat ./.github/workflows/dockerd.service > /etc/systemd/system/docker.service.d/http-proxy.conf"
+          sudo systemctl daemon-reload
+          sudo systemctl restart docker
+      - name: "Run '${{ matrix.coordinates }}' tests"
+        run: |
+          cd ${{ env.REACHABILITY_METADATA_PATH }}
+          ./gradlew test -Pcoordinates=${{ matrix.coordinates }}
+    

--- a/.github/workflows/spring.yml
+++ b/.github/workflows/spring.yml
@@ -1,0 +1,77 @@
+#
+# Copyright (c) 2024, 2024, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# The Universal Permissive License (UPL), Version 1.0
+#
+# Subject to the condition set forth below, permission is hereby granted to any
+# person obtaining a copy of this software, associated documentation and/or
+# data (collectively the "Software"), free of charge and under any and all
+# copyright rights in the Software, and any and all patent rights owned or
+# freely licensable by each licensor hereunder covering either (i) the
+# unmodified Software as contributed to or provided by such licensor, or (ii)
+# the Larger Works (as defined below), to deal in both
+#
+# (a) the Software, and
+#
+# (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+# one is included with the Software each a "Larger Work" to which the Software
+# is contributed by such licensors),
+#
+# without restriction, including without limitation the rights to copy, create
+# derivative works of, display, perform, and distribute the Software and make,
+# use, sell, offer for sale, import, export, have made, and have sold the
+# Software and the Larger Work(s), and to sublicense the foregoing rights on
+# either these or other terms.
+#
+# This license is subject to the following condition:
+#
+# The above copyright notice and either this complete permission notice or at a
+# minimum a reference to the UPL must be included in all copies or substantial
+# portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+name: Spring Tests
+
+on:
+  pull_request:
+    paths:
+      - '.github/actions/**'
+      - '.github/workflows/spring.yml'
+      - 'versions/latest-ea.json'
+  workflow_dispatch:
+
+env:
+  SPRING_PETCLINIC_PATH: ${{ github.workspace }}/spring-petclinic
+  SPRING_JAVA_VERSION: 21
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
+jobs:
+  build-graalvm-and-spring:
+    name: Native Tests
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout oracle/graal
+      uses: actions/checkout@v4
+    - name: Set up GraalVM JDK EA build
+      uses: ./.github/actions/setup-oracle-graalvm-ea-build
+      with:
+        java-version: ${{ env.SPRING_JAVA_VERSION }}
+    - name: Checkout spring-projects/spring-petclinic
+      uses: actions/checkout@v4
+      with:
+        repository: spring-projects/spring-petclinic
+        path: ${{ env.SPRING_PETCLINIC_PATH }}
+    - name: Run nativeTest in spring-petclinic
+      run: |
+        cd ${{ env.SPRING_PETCLINIC_PATH }}
+        ./gradlew nativeTest


### PR DESCRIPTION
This PR adds adapted versions of the workflows for testing Micronaut, Spring, and the Reachability Metadata from https://github.com/oracle/graal/tree/master/.github/workflows, and re-configures them so that they run against the latest EA build every time the `latest-ea.json` file is touched in a pull request.